### PR TITLE
Switch Discord RPC library to a newer one

### DIFF
--- a/Project.xml
+++ b/Project.xml
@@ -77,7 +77,7 @@
 	<haxelib name="flixel-ui" version="2.6.1"/>
 	<haxelib name="flixel-addons" version="3.2.3"/>
 
-	<haxelib name="discord_rpc" if="DISCORD_ALLOWED"/>
+	<haxelib name="hxdiscord_rpc" if="DISCORD_ALLOWED"/>
 	<haxelib name="hxvlc" if="VIDEOS_ALLOWED"/> <!--You can replace with hxcodec if you're stubborn and dont wanna use newer and better libs-->
 	<haxelib name="linc_luajit" if="LUA_ALLOWED"/>
 	

--- a/hmm.json
+++ b/hmm.json
@@ -46,11 +46,11 @@
 			"version": "1.6.1"
 		},
 		{
-			"name": "discord_rpc",
+			"name": "hxdiscord_rpc",
 			"type": "git",
 			"dir": null,
-			"ref": "master",
-			"url": "https://github.com/Aidan63/linc_discord-rpc"
+			"ref": "3538a1c2bb07b04208cd014220207f8173acdb21",
+			"url": "https://github.com/MAJigsaw77/hxdiscord_rpc"
 		},
 		{
 			"name": "linc_luajit",

--- a/setup/install_haxelibs.bat
+++ b/setup/install_haxelibs.bat
@@ -5,5 +5,5 @@ haxelib --always --quiet install flixel-ui 2.6.1
 haxelib --always --quiet install flixel-addons 3.2.3
 haxelib --always --quiet install hscript 2.5.0
 haxelib --always --quiet install hxvlc 1.6.1
-haxelib --always --quiet git discord_rpc https://github.com/Aidan63/linc_discord-rpc
+haxelib --always --quiet git hxdiscord_rpc https://github.com/MAJigsaw77/hxdiscord_rpc 3538a1c2bb07b04208cd014220207f8173acdb21
 haxelib --always --quiet git linc_luajit https://github.com/nebulazorua/linc_luajit

--- a/setup/install_haxelibs_unix.sh
+++ b/setup/install_haxelibs_unix.sh
@@ -6,5 +6,5 @@ haxelib --always --quiet install flixel-ui 2.6.1
 haxelib --always --quiet install flixel-addons 3.2.3
 haxelib --always --quiet install hscript 2.5.0
 haxelib --always --quiet install hxvlc 1.6.1
-haxelib --always --quiet git discord_rpc https://github.com/Aidan63/linc_discord-rpc
+haxelib --always --quiet git hxdiscord_rpc https://github.com/MAJigsaw77/hxdiscord_rpc 3538a1c2bb07b04208cd014220207f8173acdb21
 haxelib --always --quiet git linc_luajit https://github.com/nebulazorua/linc_luajit

--- a/source/Main.hx
+++ b/source/Main.hx
@@ -18,7 +18,7 @@ import funkin.data.SemanticVersion;
 
 using StringTools;
 
-#if discord_rpc
+#if DISCORD_ALLOWED
 import funkin.api.Discord.DiscordClient;
 #end
 
@@ -255,7 +255,7 @@ class Main extends Sprite
 		Application.current.window.alert(callstack, errorName);
 		#end
 
-		#if discord_rpc
+		#if DISCORD_ALLOWED
 		DiscordClient.shutdown(true);
 		#end
 

--- a/source/StartupState.hx
+++ b/source/StartupState.hx
@@ -26,7 +26,7 @@ import sys.thread.Mutex;
 import funkin.states.UpdaterState;
 #end
 
-#if discord_rpc
+#if DISCORD_ALLOWED
 import funkin.api.Discord.DiscordClient;
 import lime.app.Application;
 #end
@@ -138,7 +138,7 @@ class StartupState extends FlxTransitionableState
 		funkin.scripts.FunkinHScript.init();
 		#end
 		
-		#if discord_rpc
+		#if DISCORD_ALLOWED
 		Application.current.onExit.add((exitCode)->{
 			DiscordClient.shutdown();
 		});

--- a/source/funkin/ClientPrefs.hx
+++ b/source/funkin/ClientPrefs.hx
@@ -5,7 +5,7 @@ import funkin.input.Controls.KeyboardScheme;
 import flixel.util.FlxSave;
 import flixel.input.keyboard.FlxKey;
 
-#if discord_rpc
+#if DISCORD_ALLOWED
 import funkin.api.Discord.DiscordClient;
 #end
 
@@ -819,7 +819,7 @@ class ClientPrefs
 		FlxSprite.defaultAntialiasing = ClientPrefs.globalAntialiasing;
 		FlxG.stage.quality = ClientPrefs.globalAntialiasing ? openfl.display.StageQuality.BEST : openfl.display.StageQuality.LOW; // does nothing!!!!
 
-		#if discord_rpc
+		#if DISCORD_ALLOWED
 		discordRPC ? DiscordClient.start() : DiscordClient.shutdown();	
 		#end
 

--- a/source/funkin/api/Windows.hx
+++ b/source/funkin/api/Windows.hx
@@ -1,5 +1,5 @@
-#if (windows && cpp)
 package funkin.api;
+#if (windows && cpp)
 
 enum abstract MessageBoxOptions(Int) to Int {
 	var OK					= 0x00000000;

--- a/source/funkin/scripts/FunkinLua.hx
+++ b/source/funkin/scripts/FunkinLua.hx
@@ -28,7 +28,7 @@ import openfl.display.BlendMode;
 
 import funkin.modchart.SubModifier;
 
-#if discord_rpc
+#if DISCORD_ALLOWED
 import funkin.api.Discord;
 #end
 
@@ -1570,7 +1570,7 @@ class FunkinLua extends FunkinScript
 		});
 
 		addCallback("changePresence", function(details:String, state:Null<String>, ?smallImageKey:String, ?hasStartTimestamp:Bool, ?endTimestamp:Float) {
-			#if discord_rpc
+			#if DISCORD_ALLOWED
 			DiscordClient.changePresence(details, state, smallImageKey, hasStartTimestamp, endTimestamp);
 			#end
 		});

--- a/source/funkin/states/CreditsState.hx
+++ b/source/funkin/states/CreditsState.hx
@@ -6,7 +6,7 @@ import flixel.text.FlxText;
 import flixel.tweens.*;
 import flixel.util.FlxColor;
 
-#if discord_rpc
+#if DISCORD_ALLOWED
 import funkin.api.Discord.DiscordClient;
 #end
 #if sys
@@ -65,7 +65,7 @@ class CreditsState extends MusicBeatState
 
 	override function create()
 	{
-		#if discord_rpc
+		#if DISCORD_ALLOWED
 		// Updating Discord Rich Presence
 		DiscordClient.changePresence("In the Menus", null);
 		#end

--- a/source/funkin/states/MainMenuState.hx
+++ b/source/funkin/states/MainMenuState.hx
@@ -20,7 +20,7 @@ import flixel.input.keyboard.FlxKey;
 
 using StringTools;
 
-#if discord_rpc
+#if DISCORD_ALLOWED
 import funkin.api.Discord.DiscordClient;
 #end
 
@@ -51,7 +51,7 @@ class MainMenuState extends MusicBeatState
 
 	override function create()
 	{
-		#if discord_rpc
+		#if DISCORD_ALLOWED
 		// Updating Discord Rich Presence
 		DiscordClient.changePresence("In the Menus", null);
 		#end

--- a/source/funkin/states/PlayState.hx
+++ b/source/funkin/states/PlayState.hx
@@ -49,7 +49,7 @@ import openfl.filters.ShaderFilter;
 
 using StringTools;
 
-#if discord_rpc
+#if DISCORD_ALLOWED
 import funkin.api.Discord.DiscordClient;
 #end
 
@@ -338,7 +338,7 @@ class PlayState extends MusicBeatState
 	@:noCompletion public var playerStrums:FlxTypedGroup<StrumNote>;
 	#end
 
-	#if discord_rpc
+	#if DISCORD_ALLOWED
 	// Discord RPC variables
 	var detailsText:String = "";
 	var detailsPausedText:String = "";
@@ -988,7 +988,7 @@ class PlayState extends MusicBeatState
 		// EVENT AND NOTE SCRIPTS WILL GET LOADED HERE
 		generateSong(SONG.song);
 
-		#if discord_rpc
+		#if DISCORD_ALLOWED
 		// Discord RPC texts
 		detailsText = isStoryMode ? "Story Mode" : "Freeplay";
 		detailsPausedText = "Paused - " + detailsText;
@@ -1703,7 +1703,7 @@ class PlayState extends MusicBeatState
 
 		resyncVocals();
 
-		#if discord_rpc
+		#if DISCORD_ALLOWED
 		// Updating Discord Rich Presence (with Time Left)
 		DiscordClient.changePresence(detailsText, SONG.song, songName, true, songLength);
 		#end
@@ -2488,7 +2488,7 @@ class PlayState extends MusicBeatState
 			hud.alpha = ClientPrefs.hudOpacity;
 
 
-			#if discord_rpc
+			#if DISCORD_ALLOWED
 			if (Conductor.songPosition > 0.0)
 			{
 				DiscordClient.changePresence(detailsText, SONG.song, songName, true, songLength - Conductor.songPosition - ClientPrefs.noteOffset);
@@ -2505,7 +2505,7 @@ class PlayState extends MusicBeatState
 
 	override public function onFocus():Void
 	{
-		#if discord_rpc
+		#if DISCORD_ALLOWED
 		if (!isDead && !paused)
 		{
 			if (Conductor.songPosition > 0.0)
@@ -2524,7 +2524,7 @@ class PlayState extends MusicBeatState
 
 	override public function onFocusLost():Void
 	{
-		#if discord_rpc
+		#if DISCORD_ALLOWED
 		if (!isDead)
 			DiscordClient.changePresence(detailsPausedText, SONG.song, songName);
 		#end
@@ -2844,7 +2844,7 @@ class PlayState extends MusicBeatState
 		if (FlxG.keys.pressed.SHIFT) ChartingState.curSec = curSection;
 		MusicBeatState.switchState(new ChartingState());
 
-		#if discord_rpc
+		#if DISCORD_ALLOWED
 		DiscordClient.changePresence("Chart Editor", null, null, true);
 		#end
 	}
@@ -2904,7 +2904,7 @@ class PlayState extends MusicBeatState
 				char.isPlayer
 			));
 
-			#if discord_rpc
+			#if DISCORD_ALLOWED
 			// Game Over doesn't get his own variable because it's only used here
 			DiscordClient.changePresence("Game Over - " + detailsText, SONG.song, songName);
 			#end
@@ -4779,7 +4779,7 @@ class PlayState extends MusicBeatState
 				if (OpenPauseMenu)
 					openSubState(new PauseSubState(boyfriend.getScreenPosition().x, boyfriend.getScreenPosition().y));
 
-				#if discord_rpc
+				#if DISCORD_ALLOWED
 				DiscordClient.changePresence(detailsPausedText, SONG.song, songName);
 				#end
 			}

--- a/source/funkin/states/SongSelectState.hx
+++ b/source/funkin/states/SongSelectState.hx
@@ -5,7 +5,7 @@ import funkin.data.Song;
 import funkin.states.options.OptionsState;
 import funkin.states.editors.MasterEditorMenu;
 
-#if discord_rpc
+#if DISCORD_ALLOWED
 import funkin.api.Discord.DiscordClient;
 #end
 
@@ -79,7 +79,7 @@ class SongSelectState extends MusicBeatState
 	{
 		StartupState.load();
 
-		#if discord_rpc
+		#if DISCORD_ALLOWED
 		DiscordClient.changePresence("In the Menus", null);
 		#end
 		FlxG.camera.bgColor = 0xFF000000;

--- a/source/funkin/states/TitleState.hx
+++ b/source/funkin/states/TitleState.hx
@@ -11,7 +11,7 @@ import flixel.util.FlxTimer;
 import funkin.objects.shaders.ColorSwap;
 
 using StringTools;
-#if discord_rpc
+#if DISCORD_ALLOWED
 import funkin.api.Discord.DiscordClient;
 #end
 #if sys

--- a/source/funkin/states/editors/CharacterEditorState.hx
+++ b/source/funkin/states/editors/CharacterEditorState.hx
@@ -1,7 +1,7 @@
 package funkin.states.editors;
 
 import funkin.objects.hud.HealthIcon;
-#if discord_rpc
+#if DISCORD_ALLOWED
 import funkin.api.Discord.DiscordClient;
 #end
 import funkin.objects.Character;
@@ -1174,7 +1174,7 @@ class CharacterEditorState extends MusicBeatState
 	}
 
 	function updateDiscordPresence() {
-		#if discord_rpc
+		#if DISCORD_ALLOWED
 		// Updating Discord Rich Presence
 		DiscordClient.changePresence("Character Editor", "Character: " + daAnim, leHealthIcon.getCharacter());
 		#end

--- a/source/funkin/states/editors/ChartingState.hx
+++ b/source/funkin/states/editors/ChartingState.hx
@@ -37,7 +37,7 @@ import haxe.io.Bytes;
 import openfl.geom.Rectangle;
 import flixel.util.FlxSort;
 
-#if discord_rpc
+#if DISCORD_ALLOWED
 import funkin.api.Discord.DiscordClient;
 #end
 
@@ -274,7 +274,7 @@ class ChartingState extends MusicBeatState
 
 		// Paths.clearMemory();
 
-		#if discord_rpc
+		#if DISCORD_ALLOWED
 		// Updating Discord Rich Presence
 		DiscordClient.changePresence("Chart Editor", StringTools.replace(_song.song, '-', ' '));
 		#end

--- a/source/funkin/states/editors/MasterEditorMenu.hx
+++ b/source/funkin/states/editors/MasterEditorMenu.hx
@@ -1,6 +1,6 @@
 package funkin.states.editors;
 
-#if discord_rpc
+#if DISCORD_ALLOWED
 import funkin.api.Discord.DiscordClient;
 #end
 
@@ -33,7 +33,7 @@ class MasterEditorMenu extends MusicBeatState
 	override function create()
 	{
 		FlxG.camera.bgColor = FlxColor.BLACK;
-		#if discord_rpc
+		#if DISCORD_ALLOWED
 		// Updating Discord Rich Presence
 		DiscordClient.changePresence("Editors Menu", null);
 		#end

--- a/source/funkin/states/editors/StageBuilderState.hx
+++ b/source/funkin/states/editors/StageBuilderState.hx
@@ -799,7 +799,7 @@ class StageBuilderState extends MusicBeatState
 
     override public function create()
     {
-		#if discord_rpc
+		#if DISCORD_ALLOWED
 		// Updating Discord Rich Presence
 		funkin.api.Discord.DiscordClient.changePresence("Stage Builder", null);
 		#end

--- a/source/funkin/states/editors/StageEditorState.hx
+++ b/source/funkin/states/editors/StageEditorState.hx
@@ -21,7 +21,7 @@ using StringTools;
 #if sys
 import sys.FileSystem;
 #end
-#if discord_rpc
+#if DISCORD_ALLOWED
 import funkin.api.Discord.DiscordClient;
 #end
 
@@ -139,7 +139,7 @@ class StageEditorState extends MusicBeatState{
 
 	override function create()
 	{
-		#if discord_rpc
+		#if DISCORD_ALLOWED
 		// Updating Discord Rich Presence
 		DiscordClient.changePresence("In the Stage Editor", null);
 

--- a/source/funkin/states/options/OptionsSubstate.hx
+++ b/source/funkin/states/options/OptionsSubstate.hx
@@ -18,7 +18,7 @@ import flixel.util.FlxColor;
 import flixel.addons.ui.FlxUI9SliceSprite;
 import openfl.geom.Rectangle;
 
-#if discord_rpc
+#if DISCORD_ALLOWED
 import funkin.api.Discord;
 #end
 
@@ -41,7 +41,7 @@ class OptionsSubstate extends MusicBeatSubstate
 		"ui",
 		"video",
 		"controls",
-		#if (discord_rpc || DO_AUTO_UPDATE) "misc", #end 
+		#if (hxdiscord_rpc || DO_AUTO_UPDATE) "misc", #end 
 		/* "Accessibility" */
 	];
 
@@ -164,7 +164,7 @@ class OptionsSubstate extends MusicBeatSubstate
 		
 		"misc" => [
 			//["audio", ["masterVolume", "songVolume", "hitsoundVolume", "missVolume"]],
-			#if discord_rpc
+			#if DISCORD_ALLOWED
 			["discord", ["discordRPC"]],
 			#end
 			#if DO_AUTO_UPDATE
@@ -338,7 +338,7 @@ class OptionsSubstate extends MusicBeatSubstate
 					UpdaterState.checkOutOfDate();
 				}
 			#end
-			#if discord_rpc
+			#if DISCORD_ALLOWED
 			case 'discordRPC':
 				val ? DiscordClient.start() : DiscordClient.shutdown();
 			#end


### PR DESCRIPTION
reasoning behind this mostly comes from the fact that linc_discordrpc no longer compiles properly on systems that aren't windows, and/or if you're using haxe 4.3+

second reason would be that this library is more actively maintained than the old one, which is now archived