### PR TITLE
Reduce allocations in NoteField.hx & Fix hxvlc deprecation

### DIFF
--- a/source/funkin/objects/IndependentVideoSprite.hx
+++ b/source/funkin/objects/IndependentVideoSprite.hx
@@ -8,9 +8,14 @@ package funkin.objects;
 // TODO: add the other video libs (hxcodec and its various versions that change its API)
 
 import haxe.io.Bytes;
-import hxvlc.util.OneOfThree;
 import sys.FileSystem;
 #if (hxvlc)
+#if (hxvlc > "1.5.5")
+import hxvlc.util.typeLimit.OneOfThree;
+#else
+import hxvlc.util.OneOfThree;
+#end
+
 import hxvlc.flixel.FlxVideoSprite as VideoSprite;
 #end
 class IndependentVideoSprite extends VideoSprite {


### PR DESCRIPTION
It's a weird combo but the `hxvlc` adjustment was kinda last second because of compilation.

The `NoteField` adjustments is the real focus.
This should reduce allocations made when preparing the vertices and uv!