### PR TITLE
note batching

### DIFF
--- a/source/flixel/graphics/tile/FlxDrawTrianglesItem.hx
+++ b/source/flixel/graphics/tile/FlxDrawTrianglesItem.hx
@@ -13,6 +13,8 @@ import openfl.display.ShaderParameter;
 import openfl.display.TriangleCulling;
 import openfl.geom.ColorTransform;
 
+import funkin.objects.shaders.NoteColorSwap;
+
 typedef DrawData<T> = #if (flash || openfl >= "4.0.0") openfl.Vector<T> #else Array<T> #end;
 
 /**
@@ -28,6 +30,11 @@ class FlxDrawTrianglesItem extends FlxDrawBaseItem<FlxDrawTrianglesItem>
 	var alphas:Array<Float>;
 	var colorMultipliers:Array<Float>;
 	var colorOffsets:Array<Float>;
+
+	var hsvShifts:Array<Float>;
+	var daAlphas:Array<Float>;
+	var flashes:Array<Float>;
+	var flashColors:Array<Float>;
 	#end
 
 	public var vertices:DrawData<Float> = new DrawData<Float>();
@@ -47,6 +54,11 @@ class FlxDrawTrianglesItem extends FlxDrawBaseItem<FlxDrawTrianglesItem>
 		type = FlxDrawItemType.TRIANGLES;
 		#if !flash
 		alphas = [];
+
+		hsvShifts = [];
+		daAlphas = [];
+		flashes = [];
+		flashColors = [];
 		#end
 	}
 
@@ -69,6 +81,15 @@ class FlxDrawTrianglesItem extends FlxDrawBaseItem<FlxDrawTrianglesItem>
 		{
 			shader.colorMultiplier.value = colorMultipliers;
 			shader.colorOffset.value = colorOffsets;
+		}
+
+		if (shader is NoteColorSwapShader)
+		{
+			var swapShader:NoteColorSwapShader = cast shader;
+			swapShader.hsvShift.value = hsvShifts;
+			swapShader.daAlpha.value = daAlphas;
+			swapShader.flash.value = flashes;
+			swapShader.flashColor.value = flashColors;
 		}
 
 		setParameterValue(shader.hasTransform, true);
@@ -118,6 +139,12 @@ class FlxDrawTrianglesItem extends FlxDrawBaseItem<FlxDrawTrianglesItem>
 		colorsPosition = 0;
 		#if !flash
 		alphas.splice(0, alphas.length);
+
+		hsvShifts.splice(0, hsvShifts.length);
+		daAlphas.splice(0, daAlphas.length);
+		flashes.splice(0, flashes.length);
+		flashColors.splice(0, flashColors.length);
+
 		if (colorMultipliers != null)
 			colorMultipliers.splice(0, colorMultipliers.length);
 		if (colorOffsets != null)
@@ -138,11 +165,16 @@ class FlxDrawTrianglesItem extends FlxDrawBaseItem<FlxDrawTrianglesItem>
 		alphas = null;
 		colorMultipliers = null;
 		colorOffsets = null;
+
+		hsvShifts = null;
+		daAlphas = null;
+		flashes = null;
+		flashColors = null;
 		#end
 	}
 
 	public function addTrianglesColorArray(vertices:DrawData<Float>, indices:DrawData<Int>, uvtData:DrawData<Float>, ?colors:DrawData<Int>,
-			?position:FlxPoint, ?cameraBounds:FlxRect #if !flash, ?transforms:Array<ColorTransform> #end):Void
+			?position:FlxPoint, ?cameraBounds:FlxRect #if !flash, ?transforms:Array<ColorTransform> #end, ?colorSwap:NoteColorSwap):Void
 	{
 		if (position == null)
 			position = point.set();
@@ -153,6 +185,7 @@ class FlxDrawTrianglesItem extends FlxDrawBaseItem<FlxDrawTrianglesItem>
 		var verticesLength:Int = vertices.length;
 		var prevVerticesLength:Int = this.vertices.length;
 		var numberOfVertices:Int = Std.int(verticesLength / 2);
+		var numberOfTriangles:Int = Std.int(indices.length / 3);
 		var prevIndicesLength:Int = this.indices.length;
 		var prevUVTDataLength:Int = this.uvtData.length;
 		var prevColorsLength:Int = this.colors.length;
@@ -203,12 +236,31 @@ class FlxDrawTrianglesItem extends FlxDrawBaseItem<FlxDrawTrianglesItem>
 		cameraBounds.putWeak();
 
 		#if !flash
-		for (_ in 0...numTriangles)
+		for (_ in 0...numberOfTriangles)
 		{
 			var transform = transforms[_];
 			alphas.push(transform != null ? transform.alphaMultiplier : 1.0);
 			alphas.push(transform != null ? transform.alphaMultiplier : 1.0);
 			alphas.push(transform != null ? transform.alphaMultiplier : 1.0);
+		}
+
+		if (colorSwap != null)
+		{
+			for (i in 0...(numberOfTriangles * 3))
+			{
+				hsvShifts.push(colorSwap.hue);
+				hsvShifts.push(colorSwap.saturation);
+				hsvShifts.push(colorSwap.brightness);
+
+				daAlphas.push(colorSwap.daAlpha);
+
+				flashes.push(colorSwap.flash);
+
+				flashColors.push(colorSwap.flashR);
+				flashColors.push(colorSwap.flashG);
+				flashColors.push(colorSwap.flashB);
+				flashColors.push(colorSwap.flashA);
+			}
 		}
 
 		if (colored || hasColorOffsets)
@@ -219,7 +271,7 @@ class FlxDrawTrianglesItem extends FlxDrawBaseItem<FlxDrawTrianglesItem>
 			if (colorOffsets == null)
 				colorOffsets = [];
 
-			for (_ in 0...(numTriangles))
+			for (_ in 0...numberOfTriangles)
 			{
 				var transform = transforms[_];
 				for (_ in 0...3)
@@ -267,6 +319,7 @@ class FlxDrawTrianglesItem extends FlxDrawBaseItem<FlxDrawTrianglesItem>
 		var verticesLength:Int = vertices.length;
 		var prevVerticesLength:Int = this.vertices.length;
 		var numberOfVertices:Int = Std.int(verticesLength / 2);
+		var numberOfTriangles:Int = Std.int(indices.length / 3);
 		var prevIndicesLength:Int = this.indices.length;
 		var prevUVTDataLength:Int = this.uvtData.length;
 		var prevColorsLength:Int = this.colors.length;
@@ -332,7 +385,7 @@ class FlxDrawTrianglesItem extends FlxDrawBaseItem<FlxDrawTrianglesItem>
 		cameraBounds.putWeak();
 
 		#if !flash
-		for (_ in 0...numTriangles)
+		for (_ in 0...numberOfTriangles)
 		{
 			alphas.push(transform != null ? transform.alphaMultiplier : 1.0);
 			alphas.push(transform != null ? transform.alphaMultiplier : 1.0);
@@ -347,7 +400,7 @@ class FlxDrawTrianglesItem extends FlxDrawBaseItem<FlxDrawTrianglesItem>
 			if (colorOffsets == null)
 				colorOffsets = [];
 
-			for (_ in 0...(numTriangles * 3))
+			for (_ in 0...(numberOfTriangles * 3))
 			{
 				if(transform != null)
 				{

--- a/source/funkin/modchart/modifiers/LocalRotateModifier.hx
+++ b/source/funkin/modchart/modifiers/LocalRotateModifier.hx
@@ -31,8 +31,8 @@ class LocalRotateModifier extends NoteModifier { // this'll be rotateX in ModMan
 		VectorHelpers.rotateV3(pos, // out 
 			(getValue(player) + getSubmodValue('${prefix}${data}rotateX', player)) * FlxAngle.TO_RAD,
 			(getSubmodValue('${prefix}rotateY', player) + getSubmodValue('${prefix}${data}rotateY', player)) * FlxAngle.TO_RAD,
-			(getSubmodValue('${prefix}rotateZ', player) + getSubmodValue('${prefix}${data}rotateZ', player)) * FlxAngle.TO_RAD
-		);
+			(getSubmodValue('${prefix}rotateZ', player) + getSubmodValue('${prefix}${data}rotateZ', player)) * FlxAngle.TO_RAD,
+		pos);
 		
 		pos.z /= scale;
 		pos.incrementBy(origin);

--- a/source/funkin/objects/Note.hx
+++ b/source/funkin/objects/Note.hx
@@ -5,7 +5,7 @@ import flixel.math.FlxMath;
 import funkin.scripts.*;
 import funkin.states.PlayState;
 import funkin.states.editors.ChartingState;
-import funkin.objects.shaders.ColorSwap;
+import funkin.objects.shaders.NoteColorSwap;
 import funkin.objects.playfields.*;
 import funkin.data.JudgmentManager.Judgment;
 
@@ -226,7 +226,6 @@ class Note extends NoteObject
 	public var eventLength:Int = 0;
 
 	// etc
-	public var colorSwap:ColorSwap;
 	public var inEditor:Bool = false;
 	public var desiredZIndex:Float = 0;
 
@@ -464,8 +463,8 @@ class Note extends NoteObject
 		if (prevNote != null) 
 			prevNote.nextNote = this;
 
-		colorSwap = new ColorSwap();
-		shader = colorSwap.shader;
+		colorSwap = new NoteColorSwap();
+		shader = NoteColorSwap.shader;
 
 		if (column >= 0) 
 			this.noteMod = noteMod;

--- a/source/funkin/objects/NoteObject.hx
+++ b/source/funkin/objects/NoteObject.hx
@@ -4,6 +4,8 @@ import flixel.util.FlxDestroyUtil;
 import flixel.math.FlxPoint;
 import math.Vector3;
 
+import funkin.objects.shaders.NoteColorSwap;
+
 enum abstract ObjectType(#if cpp cpp.UInt8 #else Int #end)
 {
 	var UNKNOWN = -1;
@@ -20,6 +22,8 @@ class NoteObject extends FlxSprite {
 	public var noteData(get,set):Int; // backwards compat
 	inline function get_noteData()return column;
 	inline function set_noteData(v:Int)return column = v;
+
+	public var colorSwap:NoteColorSwap;
 
 	public var offsetX:Float = 0;
 	public var offsetY:Float = 0;

--- a/source/funkin/objects/NoteSplash.hx
+++ b/source/funkin/objects/NoteSplash.hx
@@ -3,11 +3,10 @@ package funkin.objects;
 import funkin.states.PlayState;
 import funkin.scripts.Globals;
 import flixel.FlxG;
-import funkin.objects.shaders.ColorSwap;
+import funkin.objects.shaders.NoteColorSwap;
 
 class NoteSplash extends NoteObject
 {
-	public var colorSwap:ColorSwap = null;
 	private var idleAnim:String;
 	private var textureLoaded:String = null;
 
@@ -15,8 +14,8 @@ class NoteSplash extends NoteObject
 		super(x, y);
 		objType = SPLASH;
 		
-		colorSwap = new ColorSwap();
-		shader = colorSwap.shader;
+		colorSwap = new NoteColorSwap();
+		shader = NoteColorSwap.shader;
 
 		loadAnims(PlayState.splashSkin);
 		setupNoteSplash(x, y, note);

--- a/source/funkin/objects/StrumNote.hx
+++ b/source/funkin/objects/StrumNote.hx
@@ -4,7 +4,7 @@ import funkin.states.PlayState;
 import funkin.objects.playfields.PlayField;
 import funkin.scripts.FunkinHScript;
 #if !macro
-import funkin.objects.shaders.ColorSwap;
+import funkin.objects.shaders.NoteColorSwap;
 
 using StringTools;
 #end
@@ -21,7 +21,6 @@ class StrumNote extends NoteObject
 
 	////
 	public var texture(default, set):String = null;
-	public var colorSwap:ColorSwap = new ColorSwap();
 	public var downScroll:Bool = false;
 	public var isQuant:Bool = false;
 	public var resetAnim:Float = 0;
@@ -39,12 +38,13 @@ class StrumNote extends NoteObject
 
 	public function new(x:Float, y:Float, leColumn:Int, ?playField:PlayField, ?hudSkin:String = 'default') {
 		super(x, y);
+		colorSwap = new NoteColorSwap();
+		shader = NoteColorSwap.shader;
+
 		objType = STRUM;
 		column = leColumn;
 		field = playField;
 		noteMod = hudSkin;
-		
-		shader = colorSwap.shader;
 	}
 
 	override function toString()

--- a/source/funkin/objects/playfields/NoteField.hx
+++ b/source/funkin/objects/playfields/NoteField.hx
@@ -16,6 +16,7 @@ import openfl.Vector;
 import openfl.geom.ColorTransform;
 import funkin.modchart.ModManager;
 import funkin.modchart.Modifier.RenderInfo;
+import funkin.objects.shaders.NoteColorSwap;
 import funkin.states.PlayState;
 import funkin.states.MusicBeatState;
 import haxe.ds.Vector as FastVector;
@@ -32,6 +33,7 @@ class RenderObject {
 	public var vertices:Vector<Float>;
 	public var indices:Vector<Int>;
 	public var zIndex:Float;
+	public var colorSwap:NoteColorSwap;
 }
 
 final scalePoint = new FlxPoint(1, 1);
@@ -324,6 +326,7 @@ class NoteField extends FieldBase
 				var vertices = object.vertices;
 				var uvData = object.uvData;
 				var indices = object.indices;
+				var colorSwap = object.colorSwap;
 				var transforms:Array<ColorTransform> = []; // todo use fastvector
 				var multAlpha = this.alpha * ClientPrefs.noteOpacity;
 				for (n in 0... Std.int(vertices.length / 2)){
@@ -353,7 +356,7 @@ class NoteField extends FieldBase
 
 						@:privateAccess
 						{
-							drawItem.addTrianglesColorArray(vertices, indices, uvData, null, point, camera._bounds, transforms);
+							drawItem.addTrianglesColorArray(vertices, indices, uvData, null, point, camera._bounds, transforms, colorSwap);
 						}
 						for (n in 0...transforms.length)
 							transforms[n].alphaMultiplier = alphas[n] * multAlpha;
@@ -557,7 +560,8 @@ class NoteField extends FieldBase
 			uvData: uvData,
 			vertices: vertices,
 			indices: HOLD_INDICES,
-			zIndex: zIndex
+			zIndex: zIndex,
+			colorSwap: hold.colorSwap
 		}
 	}
 
@@ -780,7 +784,8 @@ class NoteField extends FieldBase
 			uvData: uvData,
 			vertices: vertices,
 			indices: NOTE_INDICES,
-			zIndex: pos.z
+			zIndex: pos.z,
+			colorSwap: sprite.colorSwap
 		}
 	}
 

--- a/source/funkin/objects/proxies/ProxyField.hx
+++ b/source/funkin/objects/proxies/ProxyField.hx
@@ -67,6 +67,7 @@ class ProxyField extends FieldBase {
 				var vertices = object.vertices;
 				var uvData = object.uvData;
 				var indices = object.indices;
+				var colorSwap = object.colorSwap;
 				var transforms:Array<ColorTransform> = [];
 				for (n in 0...Std.int(vertices.length / 2))
 				{
@@ -95,7 +96,7 @@ class ProxyField extends FieldBase {
 						var drawItem = camera.startTrianglesBatch(graphic, shader.bitmap.filter == 4, true, null, true, shader);
 						@:privateAccess
 						{
-							drawItem.addTrianglesColorArray(vertices, indices, uvData, null, point, camera._bounds, transforms);
+							drawItem.addTrianglesColorArray(vertices, indices, uvData, null, point, camera._bounds, transforms, colorSwap);
 						}
 						for (n in 0...transforms.length)
 							transforms[n].alphaMultiplier = alphas[n];

--- a/source/funkin/objects/shaders/NoteColorSwap.hx
+++ b/source/funkin/objects/shaders/NoteColorSwap.hx
@@ -1,0 +1,126 @@
+package funkin.objects.shaders;
+
+import funkin.objects.shaders.ColorSwap;
+
+class NoteColorSwap {
+    public static final shader:NoteColorSwapShader = new NoteColorSwapShader();
+    public var hue:Float = 0;
+	public var saturation:Float = 0;
+	public var brightness:Float = 0;
+	public var daAlpha:Float = 1;
+	public var flash:Float = 0;
+
+	public var flashR:Float = 1;
+	public var flashG:Float = 1;
+	public var flashB:Float = 1;
+	public var flashA:Float = 1;
+
+    public function new() {}
+
+    inline public function setHSB(h:Float = 0, s:Float = 0, b:Float = 0) {
+		hue=h;
+		saturation=s;
+		brightness=b;
+	}
+	
+	inline public function setHSBInt(h:Int = 0, s:Int = 0, b:Int = 0) {
+		hue=h/360;
+		saturation=s/100;
+		brightness=b/100;
+	}
+
+	inline public function setHSBArray(ray:Array<Float>) {
+		ray==null ? setHSB() : setHSB(ray[0], ray[1], ray[2]);
+	}
+	
+	inline public function setHSBIntArray(ray:Array<Int>) {
+		ray==null ? setHSB() : setHSBInt(ray[0], ray[1], ray[2]);
+	}
+
+    inline public function copyFrom(colorSwap:NoteColorSwap) {
+		setHSB(
+			colorSwap.hue,
+			colorSwap.saturation,
+			colorSwap.brightness	
+		);
+	}
+
+	inline public function copyFromNormalSwap(colorSwap:ColorSwap) {
+		setHSB(
+			colorSwap.hue,
+			colorSwap.saturation,
+			colorSwap.brightness	
+		);
+	}
+}
+
+class NoteColorSwapShader extends ColorSwapShader
+{
+    @:glVertexSource('
+        #pragma header
+
+		attribute float alpha;
+		attribute vec4 colorMultiplier;
+		attribute vec4 colorOffset;
+		uniform bool hasColorTransform;
+
+		attribute vec3 hsvShift;
+		attribute float daAlpha;
+		attribute float flash;
+		attribute vec4 flashColor;
+
+        varying vec3 hsvShift_v;
+		varying float daAlpha_v;
+		varying float flash_v;
+		varying vec4 flashColor_v;
+
+        void main() {
+            #pragma body
+			openfl_Alphav = openfl_Alpha * alpha;
+
+			if (hasColorTransform)
+			{
+				openfl_ColorOffsetv = colorOffset / 255.0;
+				openfl_ColorMultiplierv = colorMultiplier;
+			}
+
+            hsvShift_v = hsvShift;
+            daAlpha_v = daAlpha;
+            flash_v = flash;
+            flashColor_v = flashColor;
+        }
+    ')
+	@:glFragmentSource('
+		#pragma header
+
+		varying vec3 hsvShift_v;
+		varying float daAlpha_v;
+		varying float flash_v;
+		varying vec4 flashColor_v;
+
+		void main()
+		{
+			vec4 color = texture2D(bitmap, openfl_TextureCoordv);
+
+			vec3 swagColor = rgb2hsv(color.rgb);
+
+			// hue
+			swagColor[0] = swagColor[0] + hsvShift_v[0];
+			// sat
+			swagColor[1] = clamp(swagColor[1] * (1.0 + hsvShift_v[1]), 0.0, 1.0);
+			// val
+			swagColor[2] = swagColor[2] * (1.0 + hsvShift_v[2]);
+
+			color.rgb = hsv2rgb(swagColor);
+
+			if(flash_v != 0.0){
+				color = mix(color, flashColor_v, flash_v) * color.a;
+			}
+			color *= daAlpha_v;
+			gl_FragColor = colorMult(color);
+		}')
+	public function new()
+	{
+		super();
+	}
+}


### PR DESCRIPTION
Compresses almost all the drawing of notes into one call!

## Before:
![image](https://github.com/user-attachments/assets/5ea2613c-89ea-4c34-b3e6-209ea7d33149)

## After:
![image](https://github.com/user-attachments/assets/a67c9493-8ee4-406e-be62-70ee3c9b141e)

This one is a bit more complex as it messes with the backend more, (Heck I'm messing with FlxDrawTrianglesItem)
but in terms of modding, it should be completely fine as long as nobody does `note.colorSwap = new ColorSwap()`, which is very unlikely due to the fact that notes already have their own instance each!