### PR TITLE
Only set paused rpc when out of focus if the option is turned on

### DIFF
--- a/source/funkin/states/PlayState.hx
+++ b/source/funkin/states/PlayState.hx
@@ -2288,7 +2288,7 @@ class PlayState extends MusicBeatState
 	override public function onFocusLost():Void
 	{
 		#if DISCORD_ALLOWED
-		if (!isDead)
+		if (ClientPrefs.autoPause && !isDead)
 			DiscordClient.changePresence(detailsPausedText, stateText, songName);
 		#end
 


### PR DESCRIPTION
Basically just don't set the rpc to say paused when auto pause is turned off because the game doesn't actually pause.