### PR TITLE
song code rewrite and stuff

### DIFF
--- a/default_content/base-game/songs/milf/metadata.json
+++ b/default_content/base-game/songs/milf/metadata.json
@@ -1,3 +1,4 @@
 {
+	"songName": "M.I.L.F",
 	"artist": "Kawai Sprite"
 }

--- a/source/funkin/Paths.hx
+++ b/source/funkin/Paths.hx
@@ -571,6 +571,9 @@ class Paths
 		return null;
 	}
 
+	public static inline function getFolderPath(folder:String = ""):String
+		return (folder == "") ? getPreloadPath() : mods(folder);
+
 	////	
 	public static var currentModDirectory(default, set):String = '';
 	static function set_currentModDirectory(v:String){

--- a/source/funkin/Paths.hx
+++ b/source/funkin/Paths.hx
@@ -252,7 +252,7 @@ class Paths
 
 	inline static public function sound(key:String, ?library:String):Null<Sound>
 	{
-		return returnSound('sounds', key, library);
+		return returnFolderSound('sounds', key, library);
 	}
 
 	inline static public function soundRandom(key:String, min:Int, max:Int, ?library:String)
@@ -262,12 +262,12 @@ class Paths
 
 	inline static public function music(key:String, ?library:String):Null<Sound>
 	{
-		return returnSound('music', key, library);
+		return returnFolderSound('music', key, library);
 	}
 
 	inline static public function track(song:String, track:String):Null<Sound>
 	{
-		return returnSound('songs', '${formatToSongPath(song)}/$track');
+		return returnFolderSound('songs', '${formatToSongPath(song)}/$track');
 	}
 
 	inline static public function voices(song:String):Null<Sound>
@@ -528,29 +528,30 @@ class Paths
 		return getPath('$path/$key.$SOUND_EXT');
 	}
 
-	public static function returnSound(path:String, key:String, ?library:String)
-	{
-		var gottenPath:String = soundPath(path, key, library);
-	
-		if (currentTrackedSounds.exists(gottenPath)) {
-			if (!localTrackedAssets.contains(gottenPath))
-				localTrackedAssets.push(gottenPath);
+	inline public static function returnFolderSound(path:String, key:String, ?library:String)
+		return returnSound(soundPath(path, key, library), library);
 
-			return currentTrackedSounds.get(gottenPath);
+	public static function returnSound(path:String, ?library:String)
+	{	
+		if (currentTrackedSounds.exists(path)) {
+			if (!localTrackedAssets.contains(path))
+				localTrackedAssets.push(path);
+
+			return currentTrackedSounds.get(path);
 		}
 		
-		var sound = getSound(gottenPath);
+		var sound = getSound(path);
 		if (sound != null) {
-			currentTrackedSounds.set(gottenPath, sound);
+			currentTrackedSounds.set(path, sound);
 	
-			if (!localTrackedAssets.contains(gottenPath))
-				localTrackedAssets.push(gottenPath);	
+			if (!localTrackedAssets.contains(path))
+				localTrackedAssets.push(path);	
 			
 			return sound;
 		}
 		
 		if (Main.showDebugTraces)
-			trace('sound $path, $key => $gottenPath returned null');
+			trace('sound $path returned null');
 		
 		return null;
 	}

--- a/source/funkin/data/Cache.hx
+++ b/source/funkin/data/Cache.hx
@@ -198,11 +198,11 @@ class Cache
 			default:
 				Paths.image(toLoad.path, toLoad.library);
 			case SOUND:
-				Paths.returnSound("sounds", toLoad.path, toLoad.library);
+				Paths.returnFolderSound("sounds", toLoad.path, toLoad.library);
 			case MUSIC:
-				Paths.returnSound("music", toLoad.path, toLoad.library);
+				Paths.returnFolderSound("music", toLoad.path, toLoad.library);
 			case SONG:
-				Paths.returnSound("songs", toLoad.path, toLoad.library);
+				Paths.returnFolderSound("songs", toLoad.path, toLoad.library);
 		}
 		
 		#if traceLoading

--- a/source/funkin/data/FNFTroll.hx
+++ b/source/funkin/data/FNFTroll.hx
@@ -212,7 +212,7 @@ class FNFTroll extends FNFLegacyBasic<TrollJSONFormat> {
 		}
 
 		data.song.metadata ??= {};
-		//data.song.metadata.songName = chart.meta.title;
+		data.song.metadata.songName = chart.meta.title;
 		data.song.metadata.artist = chart.meta.extraData.get("SONG_ARTIST");
 		data.song.metadata.charter = chart.meta.extraData.get("SONG_CHARTER");
 

--- a/source/funkin/data/Song.hx
+++ b/source/funkin/data/Song.hx
@@ -661,9 +661,10 @@ class Song
 	static public function loadSong(toPlay:Song, ?difficulty:String) {
 		Paths.currentModDirectory = toPlay.folder;
 
-		var rawDifficulty:String = difficulty;
-
-		if (difficulty == null || difficulty == "") {
+		if (difficulty == "") {
+			difficulty = "normal";
+		}
+		else if (difficulty == null) {
 			if (toPlay.charts.contains("normal"))
 				difficulty = "normal";
 			else
@@ -686,10 +687,10 @@ class Song
 			var found:Bool = false;
 			if (Paths.exists(chartsFilePath) && Paths.exists(metadataPath)) {
 				var chart = new moonchart.formats.fnf.FNFVSlice().fromFile(chartsFilePath, metadataPath);
-				if (chart.diffs.contains(rawDifficulty)) {
+				if (chart.diffs.contains(difficulty)) {
 					trace("CONVERTING FROM VSLICE");
 					
-					var converted = new SupportedFormat().fromFormat(chart, rawDifficulty);
+					var converted = new SupportedFormat().fromFormat(chart, difficulty);
 					var chart:JsonSong = cast converted.data.song;
 					chart.path = chartsFilePath;
 					chart.song = songId;
@@ -697,7 +698,7 @@ class Song
 					SONG = onLoadJson(chart);
 					found = true;
 				}else{
-					trace('VSLICE FILES DO NOT CONTAIN DIFFICULTY: $rawDifficulty');
+					trace('VSLICE FILES DO NOT CONTAIN DIFFICULTY: $difficulty');
 				}
 			}
 
@@ -732,10 +733,10 @@ class Song
 							chart = cast Type.createInstance(formatInfo.handler, []);
 							chart = chart.fromFile(filePath);
 
-							if (chart.formatMeta.supportsDiffs && !chart.diffs.contains(rawDifficulty))
+							if (chart.formatMeta.supportsDiffs && !chart.diffs.contains(difficulty))
 								continue;
 
-							var converted = new SupportedFormat().fromFormat(chart, rawDifficulty);
+							var converted = new SupportedFormat().fromFormat(chart, difficulty);
 							var chart:JsonSong = cast converted.data.song;
 							chart.path = filePath;
 							chart.song = songId;

--- a/source/funkin/data/Song.hx
+++ b/source/funkin/data/Song.hx
@@ -706,16 +706,8 @@ class Song
 
 			for (ext in moonchartExtensions) {
 				for (input in files) {
-					var path:String = '$songId/$input.$ext';
-					var filePath:String = Paths.getPath("songs/" + path);
+					var filePath:String = toPlay.getSongFile('$input.$ext');
 					var fileFormat:Format = findFormat([filePath]);
-
-					#if PE_MOD_COMPATIBILITY
-					if (fileFormat == null){
-						filePath = Paths.getPath("data/" + path);
-						fileFormat = findFormat([filePath]);
-					}
-					#end
 
 					if (fileFormat == null) continue;
 					var formatInfo:Null<FormatData> = FormatDetector.getFormatData(fileFormat);

--- a/source/funkin/data/Song.hx
+++ b/source/funkin/data/Song.hx
@@ -128,13 +128,7 @@ class Song
 	}
 
 	public function play(?chartName:String = ''){
-		if (charts.contains(chartName)) {
-			Song.playSong(this, chartName);
-			return true;
-		}
-	
-		trace('$this: Attempt to play null chart: ' + chartName);
-		return false;
+		Song.playSong(this, chartName);
 	}
 
 	public function toString()

--- a/source/funkin/data/Song.hx
+++ b/source/funkin/data/Song.hx
@@ -87,17 +87,15 @@ class Song
 {
 	public final songId:String;
 	public final folder:String = '';
-	public var difficulties:Array<String> = [];
 
 	public var charts(get, null):Array<String>;
 	public var metadata(get, null):SongMetadata;
 	public var songPath(get, null):String;
 
-	public function new(songId:String, ?folder:String, ?difficulties:Array<String>)
+	public function new(songId:String, ?folder:String)
 	{
 		this.songId = songId;
 		this.folder = folder ?? '';
-		this.difficulties = difficulties ?? [];
 	}
 
 	public function getSongFile(fileName:String)
@@ -308,19 +306,7 @@ class Song
 		#end
 
 		var allCharts:Array<String> = [for (name in charts.keys()) name];
-		var allChartsLower:Array<String> = [for (name in charts.keys()) name.toLowerCase()];
 		var chartNames:Array<String> = [];
-
-		if (song.difficulties.length > 0){
-			for(diff in song.difficulties){
-				if (allChartsLower.contains(diff)){
-					var index = allChartsLower.indexOf(diff);
-					chartNames.push(diff);
-					allCharts.splice(index, 1);
-					allChartsLower.remove(diff);
-				}
-			}
-		}
 
 		for (name in allCharts)
 			chartNames.push(name);

--- a/source/funkin/data/Song.hx
+++ b/source/funkin/data/Song.hx
@@ -134,12 +134,7 @@ class Song
 	}
 
 	function get_songPath() {
-		return if (songPath != null)
-			songPath;
-		else if (folder == '')
-			songPath = Paths.getPreloadPath('songs/$songId');
-		else
-			songPath = Paths.mods('$folder/songs/$songId');
+		return songPath ?? (songPath = Paths.getFolderPath(this.folder) + '/songs/$songId');
 	}
 
 	////
@@ -345,23 +340,11 @@ class Song
 			charts.set(fileName.substr(extension_dot, fileName.length - extension_dot - 5), true);
 		}
 
-
-		if (song.folder == "")
-		{
-			#if PE_MOD_COMPATIBILITY
-			Paths.iterateDirectory(Paths.getPreloadPath('data/$songId/'), processFileName);
-			#end
-			Paths.iterateDirectory(Paths.getPreloadPath('songs/$songId/'), processFileName);
-		}
-		#if MODS_ALLOWED
-		else
-		{
-			#if PE_MOD_COMPATIBILITY
-			Paths.iterateDirectory(Paths.mods('${song.folder}/data/$songId/'), processFileName);
-			#end
-			Paths.iterateDirectory(Paths.mods('${song.folder}/songs/$songId/'), processFileName);
-		}
+		var contentPath = Paths.getFolderPath(song.folder);
+		#if PE_MOD_COMPATIBILITY
+		Paths.iterateDirectory('$contentPath/data/$songId/', processFileName);
 		#end
+		Paths.iterateDirectory('$contentPath/songs/$songId/', processFileName);
 		
 		return [for (name in charts.keys()) name];
 		#end

--- a/source/funkin/data/Song.hx
+++ b/source/funkin/data/Song.hx
@@ -82,7 +82,6 @@ typedef SongMetadata =
 	?extraInfo:Array<String>,
 }
 
-@:structInit
 class Song
 {
 	public final songId:String;

--- a/source/funkin/data/Song.hx
+++ b/source/funkin/data/Song.hx
@@ -606,7 +606,7 @@ class Song
 			difficulty = 'normal';
 			diffSuffix = '';
 		}else{
-			difficulty = difficulty.trim().toLowerCase();
+			difficulty = Paths.formatToSongPath(difficulty);
 			diffSuffix = '-$difficulty';
 		}
 				
@@ -660,7 +660,7 @@ class Song
 
 			for (ext in moonchartExtensions) {
 				for (input in files) {
-					var path:String = Paths.formatToSongPath(songId) + '/' + Paths.formatToSongPath(input) + '.' + ext;
+					var path:String = '$songId/${Paths.formatToSongPath(input)}.$ext';
 					var filePath:String = Paths.getPath("songs/" + path);
 					var fileFormat:Format = findFormat([filePath]);
 

--- a/source/funkin/data/Song.hx
+++ b/source/funkin/data/Song.hx
@@ -661,7 +661,6 @@ class Song
 	static public function loadSong(toPlay:Song, ?difficulty:String) {
 		Paths.currentModDirectory = toPlay.folder;
 
-		var songId:String = toPlay.songId;
 		var rawDifficulty:String = difficulty;
 
 		if (difficulty == null || difficulty == "") {
@@ -671,7 +670,7 @@ class Song
 				difficulty = toPlay.charts[0];
 		}
 		
-		var diffSuffix:String = getDifficultyFileSuffix(difficulty);
+		var songId:String = toPlay.songId;
 				
 		if (Main.showDebugTraces)
 			trace('loadSong', toPlay, difficulty);
@@ -710,6 +709,7 @@ class Song
 			// Or dont since this current method lets you do a dumb thing AKA have 2 diff chart formats in a folder LOL
 
 			var files:Array<String> = [];
+			var diffSuffix:String = getDifficultyFileSuffix(difficulty);
 			if (diffSuffix != '') files.push(songId + diffSuffix);
 			files.push(songId);
 
@@ -719,7 +719,6 @@ class Song
 					var fileFormat:Format = findFormat([filePath]);
 
 					if (fileFormat == null) continue;
-					var formatInfo:Null<FormatData> = FormatDetector.getFormatData(fileFormat);
 
 					SONG = switch(fileFormat) {
 						case FNF_LEGACY_PSYCH | FNF_LEGACY | "FNF_TROLL":
@@ -728,6 +727,7 @@ class Song
 						default:
 							trace('Converting from format $fileFormat!');
 
+							var formatInfo:Null<FormatData> = FormatDetector.getFormatData(fileFormat);
 							var chart:moonchart.formats.BasicFormat<{}, {}>;
 							chart = cast Type.createInstance(formatInfo.handler, []);
 							chart = chart.fromFile(filePath);

--- a/source/funkin/data/Song.hx
+++ b/source/funkin/data/Song.hx
@@ -15,6 +15,7 @@ import funkin.data.Section.SwagSection;
 import haxe.io.Path;
 import haxe.Json;
 
+using funkin.CoolerStringTools;
 using StringTools;
 
 typedef SwagSong = {
@@ -75,7 +76,7 @@ typedef SongTracks = {
 
 typedef SongMetadata =
 {
-	// ?songName:String,
+	?songName:String,
 	?artist:String,
 	?charter:String,
 	?modcharter:String,
@@ -129,6 +130,7 @@ class Song
 			if (Main.showDebugTraces)
 				trace('$this: No metadata found. Maybe add some? $path');
 		}
+		json.songName ??= songId.replace("-", " ").capitalize();
 		
 		return metadata = json;
 	}

--- a/source/funkin/data/Song.hx
+++ b/source/funkin/data/Song.hx
@@ -87,7 +87,7 @@ class Song
 	public final songId:String;
 	public final folder:String = '';
 
-	public var songPath(get, null):String;
+	public var songPath(get, default):String;
 	public var charts(get, null):Array<String>;
 	private var metadataCache = new Map<String, SongMetadata>();
 
@@ -95,6 +95,7 @@ class Song
 	{
 		this.songId = songId;
 		this.folder = folder ?? '';
+		this.songPath = Paths.getFolderPath(this.folder) + '/songs/$songId';
 	}
 
 	public function getSongFile(fileName:String)
@@ -160,9 +161,8 @@ class Song
 	function get_charts() 
 		return charts ?? (charts = Song.getCharts(this));
 
-	function get_songPath() {
-		return songPath ?? (songPath = Paths.getFolderPath(this.folder) + '/songs/$songId');
-	}
+	function get_songPath()
+		return songPath; 
 
 	////
 

--- a/source/funkin/data/Song.hx
+++ b/source/funkin/data/Song.hx
@@ -103,12 +103,12 @@ class Song
 	public function getSongFile(fileName:String)
 		return '$songPath/$fileName';
 
-	public function play(?difficultyName:String = ''){
-		var idx = charts.indexOf(difficultyName);
+	public function play(?chartName:String = ''){
+		var idx = charts.indexOf(chartName);
 		if (idx != -1)
-			return Song.playSong(this, difficultyName, idx);
+			return Song.playSong(this, chartName, idx);
 	
-		trace('$this: Attempt to play null difficulty: ' + difficultyName);
+		trace('$this: Attempt to play null chart: ' + chartName);
 	}
 
 	public function toString()

--- a/source/funkin/data/Song.hx
+++ b/source/funkin/data/Song.hx
@@ -25,7 +25,6 @@ typedef SwagSong = {
 
 	////
 	var song:String;
-	// var displayName:String;
 	var bpm:Float;
 	var tracks:SongTracks; // currently used
 	

--- a/source/funkin/data/Song.hx
+++ b/source/funkin/data/Song.hx
@@ -104,11 +104,13 @@ class Song
 		return '$songPath/$fileName';
 
 	public function play(?chartName:String = ''){
-		var idx = charts.indexOf(chartName);
-		if (idx != -1)
-			return Song.playSong(this, chartName, idx);
+		if (charts.contains(chartName)) {
+			Song.playSong(this, chartName);
+			return true;
+		}
 	
 		trace('$this: Attempt to play null chart: ' + chartName);
+		return false;
 	}
 
 	public function toString()
@@ -609,7 +611,7 @@ class Song
 		return resultArray;
 	}
 
-	static public function loadSong(toPlay:Song, ?difficulty:String, ?difficultyIdx:Int = 1) {
+	static public function loadSong(toPlay:Song, ?difficulty:String) {
 		Paths.currentModDirectory = toPlay.folder;
 
 		var songId:String = toPlay.songId;
@@ -720,7 +722,7 @@ class Song
 		#end
 
 		PlayState.SONG = SONG;
-		PlayState.difficulty = difficultyIdx;
+		PlayState.difficulty = toPlay.charts.indexOf(difficulty);
 		PlayState.difficultyName = difficulty;
 		PlayState.isStoryMode = false;
 
@@ -736,9 +738,9 @@ class Song
 		LoadingState.loadAndSwitchState(new PlayState());	
 	}
 
-	static public function playSong(song:Song, ?difficulty:String, ?difficultyIdx:Int = 1)
+	static public function playSong(song:Song, ?difficulty:String)
 	{
-		loadSong(song, difficulty, difficultyIdx);
+		loadSong(song, difficulty);
 		switchToPlayState();
 	} 
 }

--- a/source/funkin/data/Song.hx
+++ b/source/funkin/data/Song.hx
@@ -335,6 +335,12 @@ class Song
 		#end
 	}
 
+	// TODO: GEt rid of this, just save the charts as "-normal" grrrr
+	public inline static function getDifficultyFileSuffix(diff:String) {
+		diff = Paths.formatToSongPath(diff);
+		return (diff=="" || diff=="normal") ? "" : '-$diff';
+	}
+
 	public static function loadFromJson(jsonInput:String, folder:String, ?isSongJson:Bool = true):Null<SwagSong>
 	{
 		var path:String = Paths.formatToSongPath(folder) + '/' + Paths.formatToSongPath(jsonInput) + '.json';
@@ -591,8 +597,6 @@ class Song
 		Paths.currentModDirectory = toPlay.folder;
 
 		var songId:String = toPlay.songId;
-		var diffSuffix:String;
-
 		var rawDifficulty:String = difficulty;
 
 		if (difficulty == null || difficulty == "") {
@@ -602,13 +606,7 @@ class Song
 				difficulty = toPlay.charts[0];
 		}
 		
-		if (difficulty == "normal") {
-			difficulty = 'normal';
-			diffSuffix = '';
-		}else{
-			difficulty = Paths.formatToSongPath(difficulty);
-			diffSuffix = '-$difficulty';
-		}
+		var diffSuffix:String = getDifficultyFileSuffix(difficulty);
 				
 		if (Main.showDebugTraces)
 			trace('loadSong', toPlay, difficulty);

--- a/source/funkin/data/Song.hx
+++ b/source/funkin/data/Song.hx
@@ -722,7 +722,10 @@ class Song
 		PlayState.SONG = SONG;
 		PlayState.difficulty = difficultyIdx;
 		PlayState.difficultyName = difficulty;
-		PlayState.isStoryMode = false;	
+		PlayState.isStoryMode = false;
+
+		PlayState.songPlaylist = [toPlay];
+		PlayState.songPlaylistIdx = 0;
 	}
 
 	static public function switchToPlayState()

--- a/source/funkin/data/Song.hx
+++ b/source/funkin/data/Song.hx
@@ -210,7 +210,7 @@ class Song
 	{
 		Paths.currentModDirectory = song.folder;
 		
-		final songId:String = Paths.formatToSongPath(song.songId);
+		final songId:String = song.songId;
 		final charts:Map<String, Bool> = [];
 
 		#if USING_MOONCHART
@@ -654,7 +654,7 @@ class Song
 
 			for (ext in moonchartExtensions) {
 				for (input in files) {
-					var path:String = '$songId/${Paths.formatToSongPath(input)}.$ext';
+					var path:String = '$songId/$input.$ext';
 					var filePath:String = Paths.getPath("songs/" + path);
 					var fileFormat:Format = findFormat([filePath]);
 

--- a/source/funkin/states/FreeplayState.hx
+++ b/source/funkin/states/FreeplayState.hx
@@ -131,7 +131,7 @@ class FreeplayState extends MusicBeatState
 			proceed = songLoaded == selectedSong && PlayState.SONG != null;
 		
 			if (!proceed) {
-				Song.loadSong(selectedSongData, curDiffStr, curDiffIdx);
+				Song.loadSong(selectedSongData, curDiffStr);
 				proceed = PlayState.SONG != null;
 			}
 		}
@@ -156,7 +156,7 @@ class FreeplayState extends MusicBeatState
 		// load song json and play inst
 		if (songLoaded != selectedSong){
 			songLoaded = selectedSong;
-			Song.loadSong(selectedSongData, curDiffStr, curDiffIdx);
+			Song.loadSong(selectedSongData, curDiffStr);
 			
 			if (PlayState.SONG != null){
 				var instAsset = Paths.track(PlayState.SONG.song, PlayState.SONG.tracks.inst[0]);

--- a/source/funkin/states/FreeplayState.hx
+++ b/source/funkin/states/FreeplayState.hx
@@ -65,7 +65,7 @@ class FreeplayState extends MusicBeatState
 					continue;
 				}
 				
-				menu.addTextOption(song.metadata.songName).ID = songData.length;
+				menu.addTextOption(song.getMetadata().songName).ID = songData.length;
 				songData.push(song);
 			}
 		}

--- a/source/funkin/states/FreeplayState.hx
+++ b/source/funkin/states/FreeplayState.hx
@@ -17,7 +17,7 @@ class FreeplayState extends MusicBeatState
 	public static var comingFromPlayState:Bool = false;
 
 	var menu = new AlphabetMenu();
-	var songMeta:Array<Song> = [];
+	var songData:Array<Song> = [];
 
 	var bgGrp = new FlxTypedGroup<FlxSprite>();
 	var bg:FlxSprite;
@@ -55,17 +55,20 @@ class FreeplayState extends MusicBeatState
 				continue;
 
 			for (songName in week.songs){
-				var metadata:Song = {songName: songName, folder: week.directory, difficulties: week.difficulties != null ? week.difficulties : []};
+				var songId = Paths.formatToSongPath(songName);
+				var song:Song = {
+					songId: songId, 
+					folder: week.directory, 
+					difficulties: week.difficulties ?? []
+				};
 				
-				/*
-				if (metadata.charts.length == 0){
-					trace('${week.directory}: $songName doesn\'t have any available charts!');
+				if (Main.showDebugTraces && song.charts.length == 0) {
+					trace('"$song" doesn\'t have any available charts!');
 					continue;
 				}
-				*/
 				
-				menu.addTextOption(songName.replace("-", " ").capitalize()).ID = songMeta.length;
-				songMeta.push(metadata);
+				menu.addTextOption(songName.replace("-", " ").capitalize()).ID = songData.length;
+				songData.push(song);
 			}
 		}
 
@@ -74,7 +77,7 @@ class FreeplayState extends MusicBeatState
 
 		add(menu);
 		menu.controls = controls;
-		menu.callbacks.onSelect = (selectedIdx, _) -> onSelectSong(songMeta[selectedIdx]);
+		menu.callbacks.onSelect = (selectedIdx, _) -> onSelectSong(songData[selectedIdx]);
 		menu.callbacks.onAccept = (_, _) -> onAccept();
 
 		////
@@ -194,7 +197,7 @@ class FreeplayState extends MusicBeatState
 			MusicBeatState.switchState(new funkin.states.MainMenuState());	
 			
 		}else if (controls.RESET){
-			var songName:String = selectedSongData.songName;
+			var songName:String = selectedSongData.songId;
 			var _dStrId:String = 'difficultyName_$curDiffStr';
 			
 			var diffName:String = Paths.getString(_dStrId, curDiffStr);
@@ -233,7 +236,7 @@ class FreeplayState extends MusicBeatState
 	function refreshScore()
 	{
 		var data = selectedSongData;
-		var record = Highscore.getRecord(data.songName, curDiffStr);
+		var record = Highscore.getRecord(data.songId, curDiffStr);
 
 		targetRating = Highscore.getRatingRecord(record) * 100;
 		if(ClientPrefs.showWifeScore)

--- a/source/funkin/states/FreeplayState.hx
+++ b/source/funkin/states/FreeplayState.hx
@@ -55,9 +55,8 @@ class FreeplayState extends MusicBeatState
 				continue;
 
 			for (songName in week.songs){
-				var songId = Paths.formatToSongPath(songName);
 				var song:Song = {
-					songId: songId, 
+					songId: Paths.formatToSongPath(songName), 
 					folder: week.directory, 
 					difficulties: week.difficulties ?? []
 				};
@@ -67,7 +66,7 @@ class FreeplayState extends MusicBeatState
 					continue;
 				}
 				
-				menu.addTextOption(songName.replace("-", " ").capitalize()).ID = songData.length;
+				menu.addTextOption(song.metadata.songName).ID = songData.length;
 				songData.push(song);
 			}
 		}

--- a/source/funkin/states/FreeplayState.hx
+++ b/source/funkin/states/FreeplayState.hx
@@ -57,8 +57,7 @@ class FreeplayState extends MusicBeatState
 			for (songName in week.songs){
 				var song:Song = {
 					songId: Paths.formatToSongPath(songName), 
-					folder: week.directory, 
-					difficulties: week.difficulties ?? []
+					folder: week.directory
 				};
 				
 				if (Main.showDebugTraces && song.charts.length == 0) {

--- a/source/funkin/states/FreeplayState.hx
+++ b/source/funkin/states/FreeplayState.hx
@@ -55,10 +55,10 @@ class FreeplayState extends MusicBeatState
 				continue;
 
 			for (songName in week.songs){
-				var song:Song = {
-					songId: Paths.formatToSongPath(songName), 
-					folder: week.directory
-				};
+				var song = new Song(
+					Paths.formatToSongPath(songName), 
+					week.directory
+				);
 				
 				if (Main.showDebugTraces && song.charts.length == 0) {
 					trace('"$song" doesn\'t have any available charts!');

--- a/source/funkin/states/PlayState.hx
+++ b/source/funkin/states/PlayState.hx
@@ -115,6 +115,9 @@ class PlayState extends MusicBeatState
 	public static var songPlaylist:Array<Song> = [];
 	public static var songPlaylistIdx = 0;
 
+	private static var song(get, never):Song;
+	private static function get_song() return songPlaylist[songPlaylistIdx];
+
 	public static var difficulty:Int = 1; // for psych mod shit
 	public static var difficultyName:String = 'normal'; // should NOT be set to "" when playing normal diff!!!!!
 
@@ -637,10 +640,10 @@ class PlayState extends MusicBeatState
 		Conductor.changeBPM(SONG.bpm);
 		Conductor.songPosition = Conductor.crochet * -5;
 
-		songName = Paths.formatToSongPath(SONG.song);
-		songHighscore = Highscore.getScore(SONG.song, difficultyName);
+		songName = (song?.songId) ?? Paths.formatToSongPath(SONG.song);
+		songHighscore = Highscore.getScore(songName, difficultyName);
 
-		metadata = SONG.metadata ?? Paths.json('songs/$songName/metadata.json');
+		metadata = SONG.metadata ?? (song?.metadata);
 		if (showDebugTraces && metadata == null)
 			trace('No metadata for $songName. Maybe add some?');
 
@@ -1707,7 +1710,13 @@ class PlayState extends MusicBeatState
 
 		////
 		for (trackName in songTrackNames) {
-			var newTrack = new FlxSound().loadEmbedded(Paths.track(PlayState.SONG.song, trackName));
+			var sndAsset = {
+				if (song != null)
+					Paths.returnSound(song.getSongFile(trackName) + ".ogg");
+				else
+					Paths.track(PlayState.SONG.song, trackName);
+			}
+			var newTrack = new FlxSound().loadEmbedded(sndAsset);
 			//newTrack.volume = 0.0;
 			newTrack.pitch = playbackRate;
 			newTrack.filter = sndFilter;

--- a/source/funkin/states/PlayState.hx
+++ b/source/funkin/states/PlayState.hx
@@ -1035,7 +1035,7 @@ class PlayState extends MusicBeatState
 		var stringId:String = 'difficultyName_$difficultyName';
 		displayedDifficulty = Paths.getString(stringId, difficultyName.replace("-"," ").capitalize());
 		
-		displayedSong = SONG.song.replace("-"," ").capitalize();
+		displayedSong = metadata?.songName ?? SONG.song.replace("-"," ").capitalize();
 
 		#if DISCORD_ALLOWED
 		// Discord RPC texts

--- a/source/funkin/states/PlayState.hx
+++ b/source/funkin/states/PlayState.hx
@@ -643,7 +643,7 @@ class PlayState extends MusicBeatState
 		songName = (song?.songId) ?? Paths.formatToSongPath(SONG.song);
 		songHighscore = Highscore.getScore(songName, difficultyName);
 
-		metadata = SONG.metadata ?? (song?.metadata);
+		metadata = SONG.metadata ?? (song?.getMetadata(difficultyName));
 		if (showDebugTraces && metadata == null)
 			trace('No metadata for $songName. Maybe add some?');
 

--- a/source/funkin/states/SongSelectState.hx
+++ b/source/funkin/states/SongSelectState.hx
@@ -267,8 +267,8 @@ class SongChartSelec extends MusicBeatState
 		if (controls.BACK)
 			MusicBeatState.switchState(new FreeplayState());
 		else if (controls.ACCEPT){
-			var daDiff = alts[curSel];
-			Song.loadSong(songMeta, (daDiff=="normal") ? null : daDiff);
+			Song.loadSong(songMeta, alts[curSel]);
+
 			if (FlxG.keys.pressed.SHIFT)
 				LoadingState.loadAndSwitchState(new funkin.states.editors.ChartingState());
 			else

--- a/source/funkin/states/SongSelectState.hx
+++ b/source/funkin/states/SongSelectState.hx
@@ -194,7 +194,7 @@ class SongSelectState extends MusicBeatState
 			if (charts.length > 1)
 				MusicBeatState.switchState(new SongChartSelec(songMeta[curSel], charts));
 			else if (charts.length > 0) {
-				Song.loadSong(songMeta[curSel], charts[0], 0);
+				Song.loadSong(songMeta[curSel], charts[0]);
 				if (FlxG.keys.pressed.SHIFT)
 					LoadingState.loadAndSwitchState(new funkin.states.editors.ChartingState());
 				else
@@ -268,7 +268,7 @@ class SongChartSelec extends MusicBeatState
 			MusicBeatState.switchState(new FreeplayState());
 		else if (controls.ACCEPT){
 			var daDiff = alts[curSel];
-			Song.loadSong(songMeta, (daDiff=="normal") ? null : daDiff, curSel);
+			Song.loadSong(songMeta, (daDiff=="normal") ? null : daDiff);
 			if (FlxG.keys.pressed.SHIFT)
 				LoadingState.loadAndSwitchState(new funkin.states.editors.ChartingState());
 			else

--- a/source/funkin/states/SongSelectState.hx
+++ b/source/funkin/states/SongSelectState.hx
@@ -118,7 +118,7 @@ class SongSelectState extends MusicBeatState
 				hPadding + (Math.floor(id/verticalLimit) * width), 
 				vPadding + (ySpace*(id%verticalLimit)), 
 				width, 
-				songMeta[id].songName,
+				songMeta[id].songId,
 				textSize
 			);
 			text.wordWrap = false;
@@ -241,7 +241,7 @@ class SongChartSelec extends MusicBeatState
 
 	override function create()
 	{
-		add(new FlxText(0, 5, FlxG.width, songMeta.songName).setFormat(null, 20, 0xFFFFFFFF, CENTER));
+		add(new FlxText(0, 5, FlxG.width, songMeta.songId).setFormat(null, 20, 0xFFFFFFFF, CENTER));
 
 		for (id in 0...alts.length){
 			var alt = alts[id];


### PR DESCRIPTION
Add the following functions to `Song` instances
- `getSongFile(fileName)`
- `getMetadata(chartId)`
- `getSwagSong(chartId)`

And add a `songName` field to `SongMetadata`, which is used to set the displayed name of the song
because of that `Song.songName` was replaced with `Song.songId`, this will be used to save the song's high-scores

Added a `PlayState.song` property to access the current song's `SongMetadata` and `songId` as well as audio tracks for the song

`SwagSong.song` will now be ignored for saving song high-scores and setting the song display name so long as `PlayState.song` isn't null
