### PR TITLE
remove NAPE_RELEASE_BUILD define from Project.xml

### DIFF
--- a/Project.xml
+++ b/Project.xml
@@ -179,9 +179,6 @@
 
 	<!--Disable the Flixel core debugger. Automatically gets set whenever you compile in release mode!-->
 	<haxedef name="FLX_NO_DEBUG" unless="debug" />
-
-	<!--Enable this for Nape release builds for a serious peformance improvement-->
-	<haxedef name="NAPE_RELEASE_BUILD" unless="debug" />
 	<!--
 	@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
 	@@@@@@@@@@@@@@@,,,,@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@


### PR DESCRIPTION
This define actually only does something if you're using nape, which we are not; so there is no reason to have it.