### PR TITLE
remove LINC_LUA_RELATIVE_DYNAMIC_LIB define

### DIFF
--- a/Project.xml
+++ b/Project.xml
@@ -146,9 +146,7 @@
 		<haxedef name="HXCPP_STACK_LINE" />
 		<haxedef name="openfl-enable-handle-error" />
 	</section>
-
-	<!-- NOTE TO SELF: DISABLE THIS IF ISSUES ARE FOUND -->
-	<haxedef name="LINC_LUA_RELATIVE_DYNAMIC_LIB" if="LUA_ALLOWED" /> <!-- stable luas PUT AFTER FIRST LINE WITH APP NAME AND ETC -->
+		
 	<define name="NO_PRECOMPILED_HEADERS" if="LUA_ALLOWED linux" />
 
 	<!-- <haxedef name="no_traces" if="final"/> -->


### PR DESCRIPTION
this define hasn't existed in linc_luajit in almost 4 years now
there really isn't a reason to keep it
see 
[https://github.com/AndreiRudenko/linc_luajit/commit/e0e1e43799abcfa9afcfb1edb7c29d174546ac03](https://github.com/AndreiRudenko/linc_luajit/commit/e0e1e43799abcfa9afcfb1edb7c29d174546ac03)

AndreiRudenko/linc_luajit#7