### PR TITLE
Move native code into cpp files

### DIFF
--- a/Project.xml
+++ b/Project.xml
@@ -143,7 +143,7 @@
 		<haxedef name="openfl-enable-handle-error" />
 	</section>
 		
-	<define name="NO_PRECOMPILED_HEADERS" if="LUA_ALLOWED linux" />
+	<define name="NO_PRECOMPILED_HEADERS" if="linux" />
 
 	<!-- <haxedef name="no_traces" if="final"/> -->
 

--- a/setup/unix-haxelibs.sh
+++ b/setup/unix-haxelibs.sh
@@ -5,7 +5,7 @@ haxelib --always --quiet install flixel 5.6.2
 haxelib --always --quiet install flixel-ui 2.6.1
 haxelib --always --quiet install flixel-addons 3.2.3
 haxelib --always --quiet git hscript https://github.com/nebulazorua/t-hscript
-haxelib --always --quiet install hxvlc 2.0.1
+haxelib --always --quiet  --skip-dependencies install hxvlc 2.0.1
 haxelib --always --quiet install hxdiscord_rpc 1.1.1
 haxelib --always --quiet git linc_luajit https://github.com/riconuts/linc_luajit
 haxelib --always --quiet install moonchart 0.5.0

--- a/setup/windows-haxelibs.bat
+++ b/setup/windows-haxelibs.bat
@@ -11,7 +11,7 @@ haxelib --always --quiet install flixel 5.6.2
 haxelib --always --quiet install flixel-ui 2.6.1
 haxelib --always --quiet install flixel-addons 3.2.3
 haxelib --always --quiet git hscript https://github.com/nebulazorua/t-hscript
-haxelib --always --quiet install hxvlc 2.0.1
+haxelib --always --quiet  --skip-dependencies install hxvlc 2.0.1
 haxelib --always --quiet install hxdiscord_rpc 1.1.1
 haxelib --always --quiet git linc_luajit https://github.com/riconuts/linc_luajit
 haxelib --always --quiet install moonchart 0.5.0

--- a/source/Main.hx
+++ b/source/Main.hx
@@ -163,7 +163,7 @@ class Main extends Sprite
 		#end
 
 		#if (windows && cpp)
-		Darkfriend.setDarkMode(true);
+		funkin.api.Darkfriend.setDarkMode(!funkin.api.Darkfriend.isLightTheme());
 		#end
 	}
 
@@ -250,35 +250,3 @@ class Main extends Sprite
 	}
 	#end
 }
-
-#if (windows && cpp)
-@:buildXml('
-<target id="haxe">
-    <lib name="dwmapi.lib" if="windows" />
-</target>
-')
-@:cppFileCode('
-#include <Windows.h>
-#include <cstdio>
-#include <iostream>
-#include <tchar.h>
-#include <dwmapi.h>
-#include <winuser.h>
-')
-private class Darkfriend {
-	/**
-		@see https://github.com/TBar09/hxWindowColorMode-main/
-	**/ 
-	public static function setDarkMode(isDark:Bool):Void {
-		final isDark:Int = isDark ? 1 : 0;
-		untyped __cpp__("
-			int darkMode = isDark;
-			HWND window = GetActiveWindow();
-			if (S_OK != DwmSetWindowAttribute(window, 19, &darkMode, sizeof(darkMode))) {
-				DwmSetWindowAttribute(window, 20, &darkMode, sizeof(darkMode));
-			}
-			UpdateWindow(window);
-		");
-	}
-}
-#end

--- a/source/funkin/api/Darkfriend.hx
+++ b/source/funkin/api/Darkfriend.hx
@@ -1,0 +1,17 @@
+package funkin.api;
+
+/**
+ * https://stackoverflow.com/questions/51334674/how-to-detect-windows-10-light-dark-mode-in-win32-application
+ */
+@:buildXml('<include name="../../../../source/funkin/api/build.xml" />')
+@:include("darkmode.hpp")
+extern class Darkfriend {
+	/**
+		@see https://github.com/TBar09/hxWindowColorMode-main/
+	**/ 
+	@:native("setDarkMode")
+	static function setDarkMode(isDark:Bool):Void;
+
+	@:native("isLightTheme")
+	static function isLightTheme():Bool;
+}

--- a/source/funkin/api/Linux.hx
+++ b/source/funkin/api/Linux.hx
@@ -1,10 +1,11 @@
 package funkin.api;
 
 #if (linux && cpp)
+import cpp.Int16;
 @:buildXml('<include name="../../../../source/funkin/api/build.xml" />')
-@:include("refreshrate.h")
+@:include("refreshrate.hpp")
 extern class Linux {
     @:native("getMonitorRefreshRate")
-	public static function getMonitorRefreshRate():Int;
+	static function getMonitorRefreshRate():Int16;
 }
 #end

--- a/source/funkin/api/Memory.hx
+++ b/source/funkin/api/Memory.hx
@@ -8,7 +8,7 @@ import cpp.SizeT;
  * @see https://web.archive.org/web/20190716205300/http://nadeausoftware.com/articles/2012/07/c_c_tip_how_get_process_resident_set_size_physical_memory_use
  */
 @:buildXml('<include name="../../../../source/funkin/api/build.xml" />')
-@:include("memory.h")
+@:include("memory.hpp")
 extern class Memory {
     @:native("getPeakRSS")
     static function getPeakRSS():SizeT;

--- a/source/funkin/api/build.xml
+++ b/source/funkin/api/build.xml
@@ -1,14 +1,30 @@
 <xml>
+    <pragma once="true" />
     <set name="PROJECT_DIR" value="${this_dir}" />
 
     <files id='haxe'>
         <compilervalue name="-I" value="${PROJECT_DIR}/include/" />
     </files>
 
+    <files id='__main__'>
+        <compilervalue name="-I" value="${PROJECT_DIR}/include/" />
+    </files>
+
+    <files id='trollengine_externs'>
+        <compilervalue name="-I" value="${PROJECT_DIR}/include/" />
+        <file name="${PROJECT_DIR}/src/memory.cpp" />
+        <file name="${PROJECT_DIR}/src/darkmode.cpp" if="windows" />
+        <file name="${PROJECT_DIR}/src/refreshrate.cpp" if="linux" />
+    </files>
+
     <target id="haxe">
+        <files id="trollengine_externs" />
         <section if="linux">
             <lib name="-lX11" />
             <lib name="-lXrandr" />
+        </section>
+        <section if="windows">
+            <lib name="dwmapi.lib" />
         </section>
     </target>
 </xml>

--- a/source/funkin/api/include/darkmode.hpp
+++ b/source/funkin/api/include/darkmode.hpp
@@ -1,0 +1,7 @@
+#ifndef DARKMODE_HPP
+#define DARKMODE_HPP
+
+void setDarkMode();
+bool isLightTheme();
+
+#endif // DARKMODE_HPP

--- a/source/funkin/api/include/memory.hpp
+++ b/source/funkin/api/include/memory.hpp
@@ -1,0 +1,10 @@
+#ifndef MEMORY_HPP
+#define MEMORY_HPP
+
+#include <cstddef>
+
+size_t getCurrentRSS();
+
+size_t getPeakRSS();
+
+#endif // MEMORY_HPP

--- a/source/funkin/api/include/refreshrate.hpp
+++ b/source/funkin/api/include/refreshrate.hpp
@@ -1,0 +1,6 @@
+#ifndef REFRESHRATE_HPP
+#define REFRESHRATE_HPP
+
+short getMonitorRefreshRate();
+
+#endif // REFRESHRATE_HPP

--- a/source/funkin/api/src/darkmode.cpp
+++ b/source/funkin/api/src/darkmode.cpp
@@ -1,0 +1,61 @@
+#include "darkmode.hpp"
+
+#ifdef HX_WINDOWS
+
+#include <Windows.h>
+#include <dwmapi.h>
+#include <vector>
+#include <string>
+#include <stdexcept>
+
+using namespace std;
+
+/**
+ * @see https://github.com/TBar09/hxWindowColorMode-main/
+ */
+void setDarkMode(bool isDark)
+{
+    int darkMode = isDark;
+    HWND window = GetActiveWindow();
+    if (S_OK != DwmSetWindowAttribute(window, 19, &darkMode, sizeof(darkMode)))
+    {
+        DwmSetWindowAttribute(window, 20, &darkMode, sizeof(darkMode));
+    }
+    UpdateWindow(window);
+}
+
+/**
+ * @see https://stackoverflow.com/questions/51334674/how-to-detect-windows-10-light-dark-mode-in-win32-application
+ */
+bool isLightTheme()
+{
+    // The value is expected to be a REG_DWORD, which is a signed 32-bit little-endian
+    auto buffer = std::vector<char>(4);
+    auto cbData = static_cast<DWORD>(buffer.size() * sizeof(char));
+    auto res = RegGetValueW(
+        HKEY_CURRENT_USER,
+        L"Software\\Microsoft\\Windows\\CurrentVersion\\Themes\\Personalize",
+        L"AppsUseLightTheme",
+        RRF_RT_REG_DWORD, // expected value type
+        nullptr,
+        buffer.data(),
+        &cbData);
+
+    if (res != ERROR_SUCCESS)
+    {
+        throw runtime_error("Error: error_code=" + to_string(res));
+    }
+
+    // convert bytes written to our buffer to an int, assuming little-endian
+    auto i = int(buffer[3] << 24 |
+                 buffer[2] << 16 |
+                 buffer[1] << 8 |
+                 buffer[0]);
+
+    return i == 1;
+}
+
+#else
+void setDarkMode(bool isDark) {}
+bool isLightTheme() { return true; }
+#endif

--- a/source/funkin/api/src/memory.cpp
+++ b/source/funkin/api/src/memory.cpp
@@ -1,12 +1,11 @@
+#include "memory.hpp"
+
 /*
  * Author:  David Robert Nadeau
  * Site:    http://NadeauSoftware.com/
  * License: Creative Commons Attribution 3.0 Unported License
  *          http://creativecommons.org/licenses/by/3.0/deed.en_US
  */
-
-#ifndef MEMCOUNTER_H
-#define MEMCOUNTER_H
 
 #if defined(_WIN32)
 #include <windows.h>
@@ -115,4 +114,3 @@ size_t getCurrentRSS()
     return (size_t)0L; /* Unsupported. */
 #endif
 }
-#endif

--- a/source/funkin/api/src/refreshrate.cpp
+++ b/source/funkin/api/src/refreshrate.cpp
@@ -1,7 +1,8 @@
+#ifdef HX_LINUX
 #include <X11/Xlib.h>
 #include <X11/extensions/Xrandr.h>
 
-//https://stackoverflow.com/questions/17797636/c-linux-get-the-refresh-rate-of-a-monitor
+// https://stackoverflow.com/questions/17797636/c-linux-get-the-refresh-rate-of-a-monitor
 short getMonitorRefreshRate()
 {
     Display *dpy = XOpenDisplay(NULL);
@@ -12,3 +13,9 @@ short getMonitorRefreshRate()
 
     return current_rate;
 }
+#else
+short getMonitorRefreshRate() { 
+    throw "This function should only be used on Linux!\nUse 'FlxG.stage.window.displayMode.refreshrate' on other platforms!";
+    return 0; 
+}
+#endif


### PR DESCRIPTION
Instead of having a bunch of random `untyped __cpp__` blocks everywhere

also darkmode window will only apply if dark mode is enabled on the computer
and remove the hxvlc dependencies from installing so it doesnt install lime and openfl twice